### PR TITLE
Add filter products by min/max price functionality

### DIFF
--- a/controllers/product_controllers.js
+++ b/controllers/product_controllers.js
@@ -47,6 +47,7 @@ _exports.getProducts =  async (req, res, next) => {
                     color: {$first: '$color'},
                     thumbnail: {$first: '$thumbnail'},
                     price: {$first: '$price'},
+                    currency: {$first: '$currency'},
                     sku: {$first: '$sku'}
                 }
             },

--- a/models/Product.js
+++ b/models/Product.js
@@ -16,18 +16,7 @@ const ProductSchema = new mongoose.Schema({
 	timestamps: true
 });
 
-ProductSchema.statics.parseQuery = function(query)
-{
-	let limit = query.limit;
-	let page = query.page;
-	let sort = query.sort;
-	delete query.limit;
-	delete query.page;
-	delete query.sort;
-	limit = parseInt(limit);
-	limit = isNaN(limit) ? 50 : limit;
-	page = parseInt(page);
-	page = isNaN(page) ? 1 : Math.max(1, page);
+const parseSort = (sort) => {
 	switch (sort)
 	{
 		case NEW: sort = {createdAt: -1}; break;
@@ -36,6 +25,39 @@ ProductSchema.statics.parseQuery = function(query)
 		case HIGH: sort = {price: -1}; break;
 		default: sort = null;
 	}
+	return sort;
+}
+
+const priceFilterToQuery = (min_price, max_price) => {
+	min_price = parseInt(min_price);
+	min_price = isNaN(min_price) ? null : min_price;
+	max_price = parseInt(max_price);
+	max_price = isNaN(max_price) ? null : max_price;
+	if (min_price !== null && max_price !== null)
+		return {$and: [{price: {$gte: min_price}}, {price: {$lte: max_price}}]};
+	else if (min_price !== null)
+		return {price: {$gte: min_price}};
+	else if (max_price !== null)
+		return {price: {$lte: max_price}};
+	return false;
+}
+
+ProductSchema.statics.parseQuery = function(query)
+{
+	let limit = query.limit;
+	let page = query.page;
+	let sort = parseSort(query.sort);
+	let price_query = priceFilterToQuery(query.min_price, query.max_price);
+	delete query.limit;
+	delete query.page;
+	delete query.sort;
+	delete query.min_price;
+	delete query.max_price;
+	if (price_query) query = {...query, ...price_query};
+	limit = parseInt(limit);
+	limit = isNaN(limit) ? 50 : limit;
+	page = parseInt(page);
+	page = isNaN(page) ? 1 : Math.max(1, page);
 	return [query, (page - 1) * limit, limit, sort];
 }
 


### PR DESCRIPTION
Receives an option to filter products by min_price and/or max_price as a query. Refactors parseQuery code. Modifies the grouping stage so that the currency is returned in the product information.