### PR TITLE
Product and variant schema redesign

### DIFF
--- a/controllers/product_controllers.js
+++ b/controllers/product_controllers.js
@@ -47,6 +47,7 @@ _exports.getProducts =  async (req, res, next) => {
                     color: {$first: '$color'},
                     thumbnail: {$first: '$thumbnail'},
                     price: {$first: '$price'},
+                    currency: {$first: '$currency'},
                     sku: {$first: '$sku'}
                 }
             },

--- a/controllers/product_controllers.js
+++ b/controllers/product_controllers.js
@@ -1,4 +1,3 @@
-const Product = require("../models/Product");
 const Variant = require("../models/Variant");
 
 const _exports = {};
@@ -6,66 +5,46 @@ const _exports = {};
 _exports.getProducts =  async (req, res, next) => {
     try
     {
-        const [query, offset, limit, sort] = Product.parseQuery(req.query);
-        const pipeline = [
-            {
-                $lookup: {
-                    from: 'products',
-                    localField: 'product',
-                    foreignField: '_id',
-                    as: 'product'
-                }
-            },
-            {
-                $unwind: '$product'
-            },
-            {
-                $project: {
-                    _id: 0,
-                    sku: '$_id',
-                    product_id: '$product._id',
-                    price: '$price.value',
-                    currency: '$price.currency',
-                    brand: '$product.brand',
-                    sections: '$product.sections',
-                    name: '$product.name',
-                    color: '$color',
-                    thumbnail: '$assets.thumbnail'
-                }
-            },
-            {
-                $match: query
-            },
-            {
-                $group: {
-                    _id: {
-                        color: '$color',
-                        product_id: '$product_id'
-                    },
-                    name: {$first: '$name'},
-                    brand: {$first: '$brand'},
-                    color: {$first: '$color'},
-                    thumbnail: {$first: '$thumbnail'},
-                    price: {$first: '$price'},
-                    currency: {$first: '$currency'},
-                    sku: {$first: '$sku'}
-                }
-            },
-            {
-                $project: {_id: 0}
-            }
-        ];
-        if (sort) pipeline.push({$sort: sort});
-        pipeline.push(
-            {
-                $skip: offset
-            },
-            {
-                $limit: limit
-            },
+        const [query, skip, limit, sort] = Variant.parseQuery(req.query);
+        const products = await Variant.find(query).sort(sort || {}).skip(skip).limit(limit).select({
+            _id: 1,
+            product: 1,
+            'assets.thumbnail': 1,
+            name: 1,
+            brand: 1,
+            price: 1
+        });
+        res.status(200).json(products);
+    }
+    catch(err)
+    {
+        res.sendStatus(500) && next(err);
+    }
+}
 
-        )
-        const products = await Variant.aggregate(pipeline);
+_exports.searchProducts = async (req, res, next) => {
+    try
+    {
+        const limit = Variant.parseLimit(req.query.limit);
+        const skip = Variant.parsePageToSkip(req.query.page, limit);
+        const search = req.params.search;
+        const regex = { $regex: new RegExp(`.*${search}.*`, 'i') };
+        const products = await Variant.find({
+            $or: [
+                {name: regex},
+                {brand: regex},
+                {section: regex},
+                {color: regex}
+            ]
+        }).skip(skip).limit(limit).select({
+            _id: 1,
+            product: 1,
+            'assets.thumbnail': 1,
+            name: 1,
+            brand: 1,
+            price: 1,
+            color: 1
+        });
         res.status(200).json(products);
     }
     catch(err)

--- a/models/Product.js
+++ b/models/Product.js
@@ -1,64 +1,17 @@
 const mongoose = require('mongoose');
 const sections_constants = require('../constants/SECTIONS');
-const {NEW, POPULAR, LOW, HIGH} = require('../constants/SORT').obj;
 const ProductSchema = new mongoose.Schema({
 	name: {type: String, required: true},
 	description: {type: String, required: true},
-	sections: {
-		type: [
-			{type: String, enum: sections_constants.arr}
-		], 
-		default: [sections_constants.obj.MEN]
+	section: {
+		type: String,
+		enum: sections_constants.arr,
+		default: sections_constants.obj.MEN
 	},
 	brand: {type: String, required: true}
 },
 {
 	timestamps: true
 });
-
-const parseSort = (sort) => {
-	switch (sort)
-	{
-		case NEW: sort = {createdAt: -1}; break;
-		case POPULAR: sort = {popularity_index: -1}; break;
-		case LOW: sort = {price: 1}; break;
-		case HIGH: sort = {price: -1}; break;
-		default: sort = null;
-	}
-	return sort;
-}
-
-const priceFilterToQuery = (min_price, max_price) => {
-	min_price = parseInt(min_price);
-	min_price = isNaN(min_price) ? null : min_price;
-	max_price = parseInt(max_price);
-	max_price = isNaN(max_price) ? null : max_price;
-	if (min_price !== null && max_price !== null)
-		return {$and: [{price: {$gte: min_price}}, {price: {$lte: max_price}}]};
-	else if (min_price !== null)
-		return {price: {$gte: min_price}};
-	else if (max_price !== null)
-		return {price: {$lte: max_price}};
-	return false;
-}
-
-ProductSchema.statics.parseQuery = function(query)
-{
-	let limit = query.limit;
-	let page = query.page;
-	let sort = parseSort(query.sort);
-	let price_query = priceFilterToQuery(query.min_price, query.max_price);
-	delete query.limit;
-	delete query.page;
-	delete query.sort;
-	delete query.min_price;
-	delete query.max_price;
-	if (price_query) query = {...query, ...price_query};
-	limit = parseInt(limit);
-	limit = isNaN(limit) ? 50 : limit;
-	page = parseInt(page);
-	page = isNaN(page) ? 1 : Math.max(1, page);
-	return [query, (page - 1) * limit, limit, sort];
-}
 
 module.exports = mongoose.model('Product', ProductSchema);

--- a/models/Product.js
+++ b/models/Product.js
@@ -16,18 +16,7 @@ const ProductSchema = new mongoose.Schema({
 	timestamps: true
 });
 
-ProductSchema.statics.parseQuery = function(query)
-{
-	let limit = query.limit;
-	let page = query.page;
-	let sort = query.sort;
-	delete query.limit;
-	delete query.page;
-	delete query.sort;
-	limit = parseInt(limit);
-	limit = isNaN(limit) ? 50 : limit;
-	page = parseInt(page);
-	page = isNaN(page) ? 1 : Math.max(1, page);
+const parseSort = (sort) => {
 	switch (sort)
 	{
 		case NEW: sort = {createdAt: -1}; break;
@@ -36,6 +25,39 @@ ProductSchema.statics.parseQuery = function(query)
 		case HIGH: sort = {price: -1}; break;
 		default: sort = null;
 	}
+	return sort;
+}
+
+const priceFilterToQuery = (min_price, max_price) => {
+	min_price = parseInt(min_price);
+	min_price = isNaN(min_price) ? null : min_price;
+	max_price = parseInt(max_price);
+	max_price = isNaN(max_price) ? null : max_price;
+	if (min_price !== null && max_price !== null)
+		return {$and: [{price: {$gte: min_price}}, {price: {$lte: max_price}}]};
+	else if (min_price !== null)
+		return {price: {$gte: min_price}};
+	else if (max_price !== null)
+		return {price: {$lte: max_price}};
+	return false;
+}
+
+ProductSchema.statics.parseQuery = function(query)
+{
+	let limit = query.limit;
+	let page = query.page;
+	let sort = parseSort(query.sort);
+	let price_query = priceFilterToQuery(query.min_price, query.max_price);
+	delete query.limit;
+	delete query.page;
+	delete query.sort;
+	delete query.min_price;
+	delete query.max_price;
+	if (price_query) query = {...query, ...price_query};
+	limit = parseInt(limit);
+	limit = isNaN(limit) ? 50 : limit;
+	page = parseInt(page);
+	page = isNaN(page) ? 1 : Math.max(1, page);
 	return [query, (page - 1) * limit, limit, sort];
 }
 

--- a/models/Variant.js
+++ b/models/Variant.js
@@ -1,9 +1,13 @@
 const mongoose = require('mongoose');
 const sizes_constants = require('../constants/SIZES');
 const currency_constants = require('../constants/CURRENCIES');
+const Product = require('./Product');
+const {NEW, HIGH, LOW, POPULAR} = require('../constants/SORT').obj;
 const VariantSchema = new mongoose.Schema({
-    size: {type: String, required: true, enum: sizes_constants.arr},
-    quantity: {type: Number, required: true, min: [0, 'Quantity cannot be less than zero'], default: 0},
+    sizes: [{
+        size: {type: String, required: true, enum: sizes_constants.arr},
+        stock: {type: Number, required: true, min: [0, 'Quantity cannot be less than zero'], default: 0}
+    }],
     color: {type: String, required: true},
     price: {
         currency: {type: String, enum: currency_constants.arr, default: currency_constants.obj.USD},
@@ -14,9 +18,71 @@ const VariantSchema = new mongoose.Schema({
         images: [String]
     },
     popularity_index: {type: Number, default: 0},
-    product: {type: mongoose.Types.ObjectId, required: true}
+    product: {type: mongoose.Types.ObjectId, required: true, ref: Product},
+    //duplicated fields
+    name: {type: String, required: true},
+    brand: {type: String, required: true},
+    section: {type: String, required: true}
+
 }, {
     timestamps: true
 });
+
+VariantSchema.index({brand: 1, size: 1, color: 1, section: 1, 'price.value': 1, popularity_index: 1});
+
+VariantSchema.statics.parseSort = (sort) => {
+	switch (sort)
+	{
+		case NEW: sort = {createdAt: -1}; break;
+		case POPULAR: sort = {popularity_index: -1}; break;
+		case LOW: sort = {price: 1}; break;
+		case HIGH: sort = {price: -1}; break;
+		default: sort = null;
+	}
+	return sort;
+}
+
+VariantSchema.statics.priceFilterToQuery = (min_price, max_price) => {
+	min_price = parseInt(min_price);
+	min_price = isNaN(min_price) ? null : min_price;
+	max_price = parseInt(max_price);
+	max_price = isNaN(max_price) ? null : max_price;
+	if (min_price !== null && max_price !== null)
+		return {$and: [{'price.value': {$gte: min_price}}, {'price.value': {$lte: max_price}}]};
+	else if (min_price !== null)
+		return {'price.value': {$gte: min_price}};
+	else if (max_price !== null)
+		return {'price.value': {$lte: max_price}};
+	return false;
+}
+VariantSchema.statics.parseLimit = (limit) => {
+    limit = parseInt(limit);
+	limit = isNaN(limit) ? 50 : limit;
+    return limit;
+}
+
+VariantSchema.statics.parsePageToSkip = (page, limit) => {
+    page = parseInt(page);
+	page = isNaN(page) ? 1 : Math.max(1, page);
+    return (page - 1) * limit;
+}
+
+VariantSchema.statics.parseQuery = function(query)
+{
+	let limit = this.parseLimit(query.limit);
+	let skip = this.parsePageToSkip(query.page, limit);
+	let sort = this.parseSort(query.sort);
+	let price_query = this.priceFilterToQuery(query.min_price, query.max_price);
+    let size = query.size;
+    delete query.size;
+	delete query.limit;
+	delete query.page;
+	delete query.sort;
+	delete query.min_price;
+	delete query.max_price;
+	if (price_query) query = {...query, ...price_query};
+    if (size) query.size = {'sizes.size': 'size'};
+	return [query,  skip, limit, sort];
+}
 
 module.exports = mongoose.model('Variant', VariantSchema);

--- a/routes/product_routes.js
+++ b/routes/product_routes.js
@@ -1,7 +1,10 @@
-const { getProducts } = require('../controllers/product_controllers');
+const { getProducts, searchProducts, getInfo } = require('../controllers/product_controllers');
 
 const router = require('express').Router();
 
 router.route('/').get(getProducts);
+
+router.route('/search/:search').get(searchProducts);
+
 
 module.exports = router;

--- a/seed/seed_test_products.js
+++ b/seed/seed_test_products.js
@@ -38,42 +38,36 @@ const atoi = (str, def = 10) => {
         }
         const products = [];
         const variants = [];
-        let product_count = atoi(process.argv[2]);
-        let variant_count = atoi(process.argv[3]);
+        let product_count = atoi(process.argv[2], 10);
+        let variant_count = atoi(process.argv[3], 5);
         for (let i = product_count; i--;)
             products.push({
                 name: "Product name: " + i,
                 description: 'This is a description for product: ' + i,
-                sections: [sections[i % sections.length]],
+                section: sections[i % sections.length],
                 brand: brands[i % brands.length]
             });
-        const product_ids = (await Product.insertMany(products)).map(doc => doc._id);
-        for (let i = product_ids.length; i--;)
+        const product_documents = await Product.insertMany(products);
+        for (let i = product_documents.length; i--;)
         {
-            const color_size_map = new Map();
+            const {_id, name, brand, section} = product_documents[i];
             for (let j = variant_count; j--;)
             {
                 const color_index = j % colors.length;
                 const color = colors[color_index];
                 const img = images[color_index];
                 const price = Math.floor((5 + Math.random() * 40) * 100) / 100;
-                const size = sizes[j % sizes.length];
-                const quantity = Math.floor(Math.random() * 30 + 1)
-                if (color_size_map.has(color))
-                {
-                    const size_log = color_size_map.get(color);
-                    if (size_log.includes(size))
-                        continue;
-                    else
-                    {
-                        size_log.push(size);
-                        color_size_map.set(color, size_log);
-                    }
-                }
-                else
-                    color_size_map.set(color, [size]);
+                const variant_sizes = [];
+                for (let k = 0, kl = sizes.length; k < kl; k++)
+                    variant_sizes.push({
+                        size: sizes[k],
+                        stock: Math.floor(Math.random() * 30 + 1)
+                    });
                 variants.push({
-                    product: product_ids[i],
+                    product: _id,
+                    name,
+                    brand,
+                    section,
                     color,
                     assets: {
                         thumbnail: img,
@@ -83,8 +77,7 @@ const atoi = (str, def = 10) => {
                         currency: USD,
                         value: price
                     },
-                    size,
-                    quantity
+                    sizes: variant_sizes
                 });
             }
         }


### PR DESCRIPTION
Redesigned product and variant schemas based on mentor feedback.
Variants now have an array of sizes that includes stock (This way they are always grouped making the $group aggregation method unnecessary).
Variants also now duplicate some product fields (name, brand, section) in order to produce faster queries without the need of lookups/populate on all variants before matching.
Frequently used fields for filtering/searching that don't often change are now indexed for better performance.
However the popularity_index field is also being indexed, this will have to be reviewed at some point since it will change often and reindexing every time might be expensive. However the field is used whenever a user visits the landing page and whenever they decide to sort other listing pages by popular products so it might be worth it.