### PR TITLE
Fix product controllers, models and seed method

### DIFF
--- a/controllers/product_controllers.js
+++ b/controllers/product_controllers.js
@@ -4,7 +4,7 @@ const Product = require("../models/Product");
 module.exports.getProducts =  async (req, res, next) => {
     try
     {
-        const productQuery = Product.parseQuery(req.body);
+        const productQuery = Product.parseQuery(req.query);
         const productIds = (await Product.find(productQuery).select({ _id: 1})).map( ({_id}) => _id );
 
         const [query, skip, limit, sort] = Variant.parseQuery(req.query);

--- a/controllers/product_controllers.js
+++ b/controllers/product_controllers.js
@@ -1,21 +1,24 @@
 const Variant = require("../models/Variant");
+const Product = require("../models/Product");
 
 module.exports.getProducts =  async (req, res, next) => {
     try
     {
+        const productQuery = Product.parseQuery(req.body);
+        const productIds = (await Product.find(productQuery).select({ _id: 1})).map( ({_id}) => _id );
+
         const [query, skip, limit, sort] = Variant.parseQuery(req.query);
+        query.product = {$in: productIds};
+
         const [products, count] = await Promise.all([
-            Variant.find(query).sort(sort || {}).skip(skip).limit(limit).select({
+            Variant.find(query).sort(sort || {}).skip(skip).limit(limit).populate('product', 'brand name').select({
                 _id: 1,
-                product: 1,
                 'assets.thumbnail': 1,
-                name: 1,
-                brand: 1,
                 price: 1
             }),
             Variant.countDocuments(query)
         ]);
-        res.status(200).json({products, pages: Math.ceil(count / limit)});
+        res.status(200).json({products, pages: Math.ceil(count / limit), productCount: count});
     }
     catch(err)
     {
@@ -26,30 +29,37 @@ module.exports.getProducts =  async (req, res, next) => {
 module.exports.searchProducts = async (req, res, next) => {
     try
     {
+        const productQuery = Product.parseQuery(req.query);
+        const search = req.params.search || "";
+        const regex = { $regex: new RegExp(`.*${search.replace(/\s+/g, ".*")}.*`, 'i') };
+
+        productQuery.$or = [
+                    {name: regex},
+                    {description: regex},
+                    {brand: regex},
+        ];
+        const productIds = (await Product.find(productQuery).select({ _id: 1})).map( ({_id}) => _id );
+        console.log(productIds, productQuery);
+
         const [query, skip, limit, sort] = Variant.parseQuery(req.query);
-        const search = req.params.search;
-        const regex = { $regex: new RegExp(`.*${search}.*`, 'i') };
+        query.$or = [
+            {product: {$in: productIds}},
+            {color: regex}
+        ];
+
         const [products, count] = await Promise.all([
             Variant.find({
-                $or: [
-                    {name: regex},
-                    {brand: regex},
-                    {section: regex},
-                    {color: regex}
-                ],
                 ...query
-            }).sort(sort || {}).skip(skip).limit(limit).select({
+            }).sort(sort || {}).skip(skip).limit(limit).populate("product", "brand name").select({
                 _id: 1,
-                product: 1,
                 'assets.thumbnail': 1,
                 name: 1,
-                brand: 1,
                 price: 1,
                 color: 1
             }),
             Variant.countDocuments(query)
         ]);
-        res.status(200).json({products, pages: Math.ceil(count / limit)});
+        res.status(200).json({products, pages: Math.ceil(count / limit), productCount: count});
     }
     catch(err)
     {

--- a/models/Product.js
+++ b/models/Product.js
@@ -14,4 +14,22 @@ const ProductSchema = new mongoose.Schema({
 	timestamps: true
 });
 
+ProductSchema.statics.parseQuery = function(query)
+{
+	const result = {};
+	if (query.name) 
+		result.name = query.name;
+	if (query.description) 
+		result.description;
+	if (query.section) 
+		result.section = query.section;
+	if (query.brand) 
+		result.brand = query.brand;
+	delete query.name;
+	delete query.brand;
+	delete query.section;
+	delete query.description;
+	return (result);
+}
+
 module.exports = mongoose.model('Product', ProductSchema);

--- a/models/Product.js
+++ b/models/Product.js
@@ -19,8 +19,6 @@ ProductSchema.statics.parseQuery = function(query)
 	const result = {};
 	if (query.name) 
 		result.name = query.name;
-	if (query.description) 
-		result.description;
 	if (query.section) 
 		result.section = query.section;
 	if (query.brand) 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "main": "app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "nodemon ./app.js"
+    "dev": "nodemon ./app.js",
+    "nvim":"find ./ -type f -name \"*.js\" ! -path \"*/node_modules/*\" -exec nvim {} +"
   },
   "keywords": [],
   "author": "",

--- a/seed/seed_test_products.js
+++ b/seed/seed_test_products.js
@@ -8,7 +8,7 @@ const sizes = require('../constants/size').arr;
 const brands = ["NIKE", "H&M", "GC", "ADIDAS"];
 const colors = ["RED", "BLUE", "YELLOW", "GREEN", "PURPLE", "PINK", "BROWN", "BLACK", "WHITE", "MULTI"];
 const images = [
-    'https://cdn.pixabay.com/photo/2016/12/06/09/31/blank-1886008_640.png',//red
+    'https://imgs.search.brave.com/t4IfTANR1iwFLt8G1PRuwKOpNz4uQfZpJnDsvLs8RlY/rs:fit:860:0:0/g:ce/aHR0cHM6Ly9tLm1l/ZGlhLWFtYXpvbi5j/b20vaW1hZ2VzL0kv/NzFrWlJ0bVY4Ukwu/anBn',//red
     'https://cdn.pixabay.com/photo/2017/02/15/11/42/t-shirt-2068353_640.png',//blue
     'https://media.istockphoto.com/id/831591150/photo/yellow-t-shirts-front-and-back-used-as-design-template.jpg?b=1&s=170667a&w=0&k=20&c=4Wm0BXRriJONblmVKGx5aTiJLeJy0oS-f22zB6zL8us=',//yellow
     'https://cdn.pixabay.com/photo/2016/11/23/06/57/isolated-t-shirt-1852114_640.png',//green
@@ -16,7 +16,7 @@ const images = [
     'https://cdn.pixabay.com/photo/2017/10/22/19/10/shirt-2878907_960_720.jpg',//pink
     'https://media.istockphoto.com/id/1295521820/photo/mens-brown-dark-chocolate-blank-t-shirt-template-from-two-sides-natural-shape-on-invisible.jpg?s=1024x1024&w=is&k=20&c=rNSJ1PE_vUadGU7ObCJn2fTp9UNmh2aRumGjnl-p_WU=',//brown
     'https://cdn.pixabay.com/photo/2016/12/06/09/30/blank-1886001_640.png',//black
-    'https://cdn.pixabay.com/photo/2016/12/06/09/31/blank-1886013_640.png', //white
+    'https://imgs.search.brave.com/lGmDn-pHilmKXPsq49Kdx9mqXdbo6upsCNDQ42c1Cag/rs:fit:500:0:0/g:ce/aHR0cHM6Ly9tLm1l/ZGlhLWFtYXpvbi5j/b20vaW1hZ2VzL0kv/NzEtWExsMUl3eUwu/anBn', //white
     'https://media.istockphoto.com/id/859807234/photo/tie-dye-shirt.jpg?s=1024x1024&w=is&k=20&c=uvY2j0OLFOPSzAh2WhBnsBdr-aMg1oAbZ8-0oCkmBOo=',//multi
 ];
 
@@ -57,12 +57,28 @@ const atoi = (str, def = 10) => {
                 const color = colors[colorIndex];
                 const img = images[colorIndex];
                 const price = Math.floor((5 + Math.random() * 40) * 100) / 100;
-                const variantSizes = [];
-                for (let k = 0, kl = sizes.length; k < kl; k++)
-                    variantSizes.push({
-                        size: sizes[k],
-                        stock: Math.floor(Math.random() * 30 + 1)
-                    });
+                const stock = {
+                    XS: {
+                        size: "XS",
+                        stock: Math.floor(Math.random() * 30)
+                    },
+                    S: {
+                        size: "S",
+                        stock: Math.floor(Math.random() * 30)
+                    },
+                    M: {
+                        size: "M",
+                        stock: Math.floor(Math.random() * 30)
+                    },
+                    L: {
+                        size: "L",
+                        stock: Math.floor(Math.random() * 30)
+                    },
+                    XL: {
+                        size: "XL",
+                        stock: Math.floor(Math.random() * 30)
+                    },
+                };
                 variants.push({
                     product: _id,
                     name,
@@ -77,7 +93,7 @@ const atoi = (str, def = 10) => {
                         currency: USD,
                         value: price
                     },
-                    sizes: variantSizes
+                    stock: stock
                 });
             }
         }

--- a/seed/seed_test_products.js
+++ b/seed/seed_test_products.js
@@ -6,18 +6,18 @@ const {USD} = require('../constants/currency').obj;
 const sections = require('../constants/section').arr;
 const sizes = require('../constants/size').arr;
 const brands = ["NIKE", "H&M", "GC", "ADIDAS"];
-const colors = ["RED", "BLUE", "YELLOW", "GREEN", "PURPLE", "PINK", "BROWN", "BLACK", "WHITE", "MULTI"];
-const images = [
-    'https://imgs.search.brave.com/t4IfTANR1iwFLt8G1PRuwKOpNz4uQfZpJnDsvLs8RlY/rs:fit:860:0:0/g:ce/aHR0cHM6Ly9tLm1l/ZGlhLWFtYXpvbi5j/b20vaW1hZ2VzL0kv/NzFrWlJ0bVY4Ukwu/anBn',//red
-    'https://cdn.pixabay.com/photo/2017/02/15/11/42/t-shirt-2068353_640.png',//blue
-    'https://media.istockphoto.com/id/831591150/photo/yellow-t-shirts-front-and-back-used-as-design-template.jpg?b=1&s=170667a&w=0&k=20&c=4Wm0BXRriJONblmVKGx5aTiJLeJy0oS-f22zB6zL8us=',//yellow
-    'https://cdn.pixabay.com/photo/2016/11/23/06/57/isolated-t-shirt-1852114_640.png',//green
-    'https://media.istockphoto.com/id/1354823135/photo/violet-t-shirt-template-men-isolated-on-white-tee-shirt-blank-as-design-mockup-front-view.jpg?s=1024x1024&w=is&k=20&c=42T1swRTZxbYZJTXgB5Sd_BH3acg88Xg3Ws4zHB3UHw=', //purple
-    'https://cdn.pixabay.com/photo/2017/10/22/19/10/shirt-2878907_960_720.jpg',//pink
-    'https://media.istockphoto.com/id/1295521820/photo/mens-brown-dark-chocolate-blank-t-shirt-template-from-two-sides-natural-shape-on-invisible.jpg?s=1024x1024&w=is&k=20&c=rNSJ1PE_vUadGU7ObCJn2fTp9UNmh2aRumGjnl-p_WU=',//brown
-    'https://cdn.pixabay.com/photo/2016/12/06/09/30/blank-1886001_640.png',//black
-    'https://imgs.search.brave.com/lGmDn-pHilmKXPsq49Kdx9mqXdbo6upsCNDQ42c1Cag/rs:fit:500:0:0/g:ce/aHR0cHM6Ly9tLm1l/ZGlhLWFtYXpvbi5j/b20vaW1hZ2VzL0kv/NzEtWExsMUl3eUwu/anBn', //white
-    'https://media.istockphoto.com/id/859807234/photo/tie-dye-shirt.jpg?s=1024x1024&w=is&k=20&c=uvY2j0OLFOPSzAh2WhBnsBdr-aMg1oAbZ8-0oCkmBOo=',//multi
+const colors = ["RED", "BLUE", "YELLOW", "GREEN"];
+const maleImages = [
+    'https://imgs.search.brave.com/mbYwiUtddz9mHn6BNwsRIGbjRtuJPB8-3N8TP2ii_30/rs:fit:860:0:0/g:ce/aHR0cHM6Ly9tLm1l/ZGlhLWFtYXpvbi5j/b20vaW1hZ2VzL0kv/ODFSUlo2NkF1dUwu/anBn',//red
+    'https://imgs.search.brave.com/WDl---3CdkdvFbglUAGaf7H0YY2UD9TrjMcpvswdqkc/rs:fit:860:0:0/g:ce/aHR0cHM6Ly9tLm1l/ZGlhLWFtYXpvbi5j/b20vaW1hZ2VzL0kv/ODFhKzBQRXNIQ0wu/anBn',//blue
+    'https://imgs.search.brave.com/VT_kq4KEtQOzVyv9pq6lM1qHuXVNGrxTJdcmYWEXycQ/rs:fit:500:0:0/g:ce/aHR0cHM6Ly9tLm1l/ZGlhLWFtYXpvbi5j/b20vaW1hZ2VzL0kv/NzFmeG5lV2wrRUwu/anBn',//yellow
+    'https://imgs.search.brave.com/wb6ZXs93SiHADN1QRi6-wDqBZwEBJo5wzZSnLbCKXIc/rs:fit:500:0:0/g:ce/aHR0cHM6Ly9tLm1l/ZGlhLWFtYXpvbi5j/b20vaW1hZ2VzL0kv/NjE5emN2SzFwZFMu/anBn'//green
+];
+const femaleImages = [
+    'https://imgs.search.brave.com/nQXKCq67jLP2qYbZuk5XtQNuuqs8cmoyPq_djQmbB9A/rs:fit:500:0:0/g:ce/aHR0cHM6Ly9tLm1l/ZGlhLWFtYXpvbi5j/b20vaW1hZ2VzL0kv/ODFQd3VJbFdCK0wu/anBn',//red
+    'https://imgs.search.brave.com/8sUSR4hTXQVFLFjbc1GUG7GN6IhNskUUt8qaVYjZ99M/rs:fit:500:0:0/g:ce/aHR0cHM6Ly9tLm1l/ZGlhLWFtYXpvbi5j/b20vaW1hZ2VzL0kv/NTEwdHpFcTdpd0wu/anBn',//blue
+    'https://imgs.search.brave.com/HMyI7mXg6ET4WX1VZMPmaICewYTrt4myCpF9TA8fQ0M/rs:fit:500:0:0/g:ce/aHR0cHM6Ly9tLm1l/ZGlhLWFtYXpvbi5j/b20vaW1hZ2VzL0kv/NjE2RmtRU0h3dEwu/anBn',//yellow
+    'https://imgs.search.brave.com/xYNBsXj7a4Y1LJc9NtrMy8TN_g5Na17b_CSyOndAM6s/rs:fit:860:0:0/g:ce/aHR0cHM6Ly9tLm1l/ZGlhLWFtYXpvbi5j/b20vaW1hZ2VzL0kv/NjFTNnpHUlpKeUwu/anBn',//green
 ];
 
 const atoi = (str, def = 10) => {
@@ -55,7 +55,7 @@ const atoi = (str, def = 10) => {
             {
                 const colorIndex = j % colors.length;
                 const color = colors[colorIndex];
-                const img = images[colorIndex];
+                const img = (section == 'men' ? maleImages : femaleImages)[colorIndex];
                 const price = Math.floor((5 + Math.random() * 40) * 100) / 100;
                 const stock = {
                     XS: {


### PR DESCRIPTION
Controllers:
Now search by products for name, description, brand and section fields and then match variants to the returned ids.
This was done to eliminate field duplication.

Models:
Add parseQuery static method to Product model.
Eliminate duplicated fields from variant.

seed_products:
Modify to represent the new model structures.